### PR TITLE
Use Pyright to check types. Update all possible places to include type hints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,17 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip' # caching pip dependencies
-      - name: install PDM and python dependencies
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v3
+      - name: install all dependencies
         run: |
-            bash ./setup.sh
-      - name: Check formatting (black)
+            pdm install -d
+      - name: Check format lint
         run: |
             pdm run lint
+      - name: Check types
+        run: |
+            pdm run typing
       - name: Test
         run: |
             pdm run test

--- a/epubhv/__init__.py
+++ b/epubhv/__init__.py
@@ -1,6 +1,0 @@
-from epubhv.epubhv import (
-    list_all_epub_in_dir,
-    _make_epub_files_dict,
-    EPUBHV,
-    Punctuation,
-)

--- a/epubhv/cli.py
+++ b/epubhv/cli.py
@@ -1,11 +1,20 @@
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
 from epubhv.epubhv import EPUBHV, list_all_epub_in_dir
 
 
-def main():
+@dataclass
+class Options:
+    epub: str
+    v: bool
+    h: bool
+    convert: str
+    punctuation: str
+
+
+def main() -> None:
     parser: ArgumentParser = ArgumentParser(formatter_class=RawTextHelpFormatter)
     parser.add_argument("epub", help="file or dir that contains epub files to change")
     parser.add_argument(
@@ -73,7 +82,15 @@ tw2t: Traditional Chinese (OpenCC Standard) to Traditional Chinese (Taiwan stand
         """,
     )
 
-    options: Namespace = parser.parse_args()
+    raw_args: Namespace = parser.parse_args()
+    options: Options = Options(
+        epub=raw_args.epub,
+        v=raw_args.v,
+        h=raw_args.h,
+        convert=raw_args.convert,
+        punctuation=raw_args.punctuation,
+    )
+
     epub_files = Path(options.epub)
     # default is to to_vertical
     method: str = "to_vertical"
@@ -83,23 +100,23 @@ tw2t: Traditional Chinese (OpenCC Standard) to Traditional Chinese (Taiwan stand
         method = "to_vertical"
     if epub_files.exists():
         if epub_files.is_dir():
-            files: List[Path] = list_all_epub_in_dir(epub_files)
+            files: set[Path] = list_all_epub_in_dir(path=epub_files)
             f: Path
             for f in files:
                 print(f"{str(f)} is {method}")
                 try:
                     epubhv: EPUBHV = EPUBHV(
-                        file_name=f,
+                        file_path=f,
                         convert_to=options.convert,
                         convert_punctuation=options.punctuation,
                     )
-                    epubhv.run(method)
-                except Exception as epubhv:
-                    print(f"{str(f)} {method} is failed by {str(epubhv)}")
+                    epubhv.run(method=method)
+                except Exception as e:
+                    print(f"{str(f)} {method} is failed by {str(e)}")
         else:
             print(f"{str(epub_files)} is {method}")
-            epubhv: EPUBHV = EPUBHV(epub_files, convert_to=options.convert)
-            epubhv.run(method)
+            epubhv: EPUBHV = EPUBHV(file_path=epub_files, convert_to=options.convert)
+            epubhv.run(method=method)
     else:
         raise Exception("Please make sure it is a dir contains epub or is a epub file.")
 

--- a/epubhv/punctuation.py
+++ b/epubhv/punctuation.py
@@ -1,15 +1,18 @@
 import re
+from typing import Dict, Literal
 
 
 class Punctuation:
-    def convert(self, text, horizontal, source_locale, target_locale):
+    def convert(
+        self, text: str, horizontal: bool, source_locale: str, target_locale: str
+    ) -> str:
         if horizontal:
             # Horizontal punctuations will be displayed as vertical
             # punctuations in vertical writing mode (but not vice versa),
             # so we'll just use horizontal ones.
             text = self.batch_replace(
-                text,
-                {
+                text=text,
+                replacement_dict={
                     "﹁": "「",
                     "﹂": "」",
                     "﹃": "『",
@@ -19,8 +22,8 @@ class Punctuation:
         if source_locale != target_locale:
             if source_locale == "hans":
                 text = self.batch_replace(
-                    text,
-                    {
+                    text=text,
+                    replacement_dict={
                         "‘": "「",
                         "’": "」",
                         "“": "『",
@@ -30,8 +33,8 @@ class Punctuation:
 
             # swap single quotes with double quotes
             text = self.batch_replace(
-                text,
-                {
+                text=text,
+                replacement_dict={
                     "『": "「",
                     "』": "」",
                     "「": "『",
@@ -41,8 +44,8 @@ class Punctuation:
 
             if target_locale == "hans" and horizontal:
                 text = self.batch_replace(
-                    text,
-                    {
+                    text=text,
+                    replacement_dict={
                         "「": "‘",
                         "」": "’",
                         "『": "“",
@@ -52,12 +55,12 @@ class Punctuation:
 
         return text
 
-    def map_locale(self, x):
+    def map_locale(self, x: str) -> Literal["hans", "hant"]:
         if x in ["s", "sp"]:
             return "hans"
         return "hant"
 
-    def batch_replace(self, text: str, replacement_dict: dict):
+    def batch_replace(self, text: str, replacement_dict: Dict[str, str]) -> str:
         if len(replacement_dict) == 0:
             return text
         return re.sub(

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "style", "test"]
+groups = ["default", "style", "test", "typing"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:a0717b0868c7fb58eb04a0fcbddc04562820c041f85ebaf98a09dd7be0910b98"
+content_hash = "sha256:ccf6a56024f0a4f6b4b19415960db3f73d9a3f3d77c3bef2a75a58baeb3f1c65"
 
 [[package]]
 name = "beautifulsoup4"
@@ -202,6 +202,19 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+summary = "Node.js virtual environment builder"
+dependencies = [
+    "setuptools",
+]
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[[package]]
 name = "opencc-python-reimplemented"
 version = "0.1.7"
 summary = "OpenCC made with Python"
@@ -251,6 +264,19 @@ files = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.327"
+requires_python = ">=3.7"
+summary = "Command line wrapper for pyright"
+dependencies = [
+    "nodeenv>=1.6.0",
+]
+files = [
+    {file = "pyright-1.1.327-py3-none-any.whl", hash = "sha256:3462cda239e9140276238bbdbd0b59d77406f1c2e14d8cb8c20c8e25639c6b3c"},
+    {file = "pyright-1.1.327.tar.gz", hash = "sha256:ba74148ad64f22020dbbed6781c4bdb38ecb8a7ca90dc3c87a4f08d1c0e11592"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.2"
 requires_python = ">=3.7"
@@ -266,6 +292,16 @@ dependencies = [
 files = [
     {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
     {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+]
+
+[[package]]
+name = "setuptools"
+version = "68.2.2"
+requires_python = ">=3.8"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+files = [
+    {file = "setuptools-68.2.2-py3-none-any.whl", hash = "sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"},
+    {file = "setuptools-68.2.2.tar.gz", hash = "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"},
 ]
 
 [[package]]
@@ -299,6 +335,27 @@ dependencies = [
 ]
 files = [
     {file = "typed-argument-parser-1.8.1.tar.gz", hash = "sha256:a3c286a6fac597da558c13b13e7090935803f43f47e46e51ed3c1d20959f47b9"},
+]
+
+[[package]]
+name = "types-beautifulsoup4"
+version = "4.12.0.6"
+summary = "Typing stubs for beautifulsoup4"
+dependencies = [
+    "types-html5lib",
+]
+files = [
+    {file = "types-beautifulsoup4-4.12.0.6.tar.gz", hash = "sha256:045ab285d3e540186e16133612f43f67e31f910e6d7578906b43a0ad8f811347"},
+    {file = "types_beautifulsoup4-4.12.0.6-py3-none-any.whl", hash = "sha256:3da00d754e73afae0ec2793253af0cb9aa1ff2c730e34b31c60313da781b4f6f"},
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.15"
+summary = "Typing stubs for html5lib"
+files = [
+    {file = "types-html5lib-1.1.11.15.tar.gz", hash = "sha256:80e1a2062d22a3affe5c28d97da30bffbf3a076d393c80fc6f1671216c1bd492"},
+    {file = "types_html5lib-1.1.11.15-py3-none-any.whl", hash = "sha256:16fe936d99b9f7fc210e2e21a2aed1b6bbbc554ad8242a6ef75f6f2bddb27e58"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,25 @@ build-backend = "pdm.backend"
 [tool.pdm.scripts]
 format = "black ."
 lint = "black . --check"
+typing = "pyright"
 test = "pytest -vv"
-all = {composite = ["lint", "test"]}
+all = { composite = ["lint", "typing", "test"] }
 
 [tool.pdm.dev-dependencies]
-test = [
-    "pytest>=7.4.2",
+test = ["pytest>=7.4.2"]
+style = ["black>=23.9.1"]
+typing = ["pyright>=1.1.327", "types-beautifulsoup4>=4.12.0.6"]
+
+
+[tool.pyright]
+include = ["epubhv", "tests"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "src/experimental",
+    "src/typestubs",
 ]
-style = [
-    "black>=23.9.1",
-]
+defineConstant = { DEBUG = true }
+
+reportMissingImports = true
+reportMissingTypeStubs = false

--- a/tests/test_epubhv.py
+++ b/tests/test_epubhv.py
@@ -3,15 +3,20 @@ from pathlib import Path
 from shutil import rmtree
 
 import opencc
-from typing import Dict
+from typing import Dict, List
 
 import pytest
-from epubhv import EPUBHV, Punctuation, _make_epub_files_dict, list_all_epub_in_dir
+from epubhv.epubhv import (
+    EPUBHV,
+    Punctuation,
+    make_epub_files_dict,
+    list_all_epub_in_dir,
+)
 
 
 @pytest.fixture
 def epub() -> EPUBHV:
-    return EPUBHV(Path("tests/test_epub/animal_farm.epub"))
+    return EPUBHV(file_path=Path("tests/test_epub/animal_farm.epub"))
 
 
 def test_find_epub_books() -> None:
@@ -31,18 +36,20 @@ def test_extract_epub_path(epub: EPUBHV) -> None:
 
 def test_make_files_dict(epub: EPUBHV) -> None:
     epub.extract_one_epub_to_dir()
-    d: Dict = dict(_make_epub_files_dict(".epub_temp_dir/animal_farm"))
+    d: Dict[str, List[Path]] = dict(
+        make_epub_files_dict(dir_path=Path(".epub_temp_dir/animal_farm"))
+    )
     assert sorted(
         [".html", ".css", ".xhtml", "", ".opf", ".ncx", ".jpg", ".xml"]
     ) == sorted(list(d.keys()))
-    assert 19 == len(d.get(".html", 0))
+    assert 19 == len(d.get(".html", []))
     rmtree(".epub_temp_dir/animal_farm")
 
 
 def test_change_epub_to_vertical():
     epub_file = Path("animal_farm-v-original.epub")
     epub_file.unlink(True)
-    b = EPUBHV("tests/test_epub/animal_farm.epub")
+    b = EPUBHV(Path("tests/test_epub/animal_farm.epub"))
     b.run()
     assert b.opf_file == Path(".epub_temp_dir/animal_farm/content.opf")
     epub_file.unlink(True)
@@ -51,12 +58,12 @@ def test_change_epub_to_vertical():
 def test_find_epub_css_files():
     lemo_output = Path("lemo-h-original.epub")
     lemo_output.unlink(True)
-    b = EPUBHV("tests/test_epub/animal_farm.epub")
-    b._make_epub_values()
+    b = EPUBHV(Path("tests/test_epub/animal_farm.epub"))
+    b.make_epub_values()
     assert b.has_css_file is False
     b.run()
     os.remove("animal_farm-v-original.epub")
-    f: EPUBHV = EPUBHV("tests/test_epub/books/lemo.epub")
+    f: EPUBHV = EPUBHV(Path("tests/test_epub/books/lemo.epub"))
     f.run("to_horizontal")
     assert lemo_output.exists()
     lemo_output.unlink(True)
@@ -67,20 +74,20 @@ def test_change_epub_covert() -> None:
         os.remove("sanguo-v-s2t-v-original.epub")
     if os.path.exists("sanguo-v-s2t.epub"):
         os.remove("sanguo-v-s2t.epub")
-    f: EPUBHV = EPUBHV("tests/test_epub/sanguo.epub", "s2t")
+    f: EPUBHV = EPUBHV(Path("tests/test_epub/sanguo.epub"), "s2t")
     f.run("to_vertical")
     assert os.path.exists("sanguo-v-s2t.epub") is True
-    q: EPUBHV = EPUBHV("sanguo-v-s2t.epub")
+    q: EPUBHV = EPUBHV(Path("sanguo-v-s2t.epub"))
     q.extract_one_epub_to_dir()
-    q._make_epub_values()
+    q.make_epub_values()
     has_t_count: int = 0
     for html_file in (
         q.files_dict.get(".html", [])
         + q.files_dict.get(".xhtml", [])
         + q.files_dict.get(".htm", [])
     ):
-        with open(html_file, "r", encoding="utf-8", errors="ignore") as f:
-            r: str = f.read()
+        with open(html_file, "r", encoding="utf-8", errors="ignore") as file:
+            r: str = file.read()
             if r.find("滾滾長江東逝水") > 0:
                 has_t_count += 1
     assert has_t_count > 0
@@ -92,13 +99,13 @@ def test_change_epub_covert() -> None:
 def test_punctuation():
     punctuation = Punctuation()
 
-    res = punctuation.convert(
+    res: str = punctuation.convert(
         "﹃我最赞成罗素先生的一句话：﹁须知参差多态，乃是幸福的本源。﹂大多数的参差多态都是敏于思索的人创造出来的。﹄",
         True,
         "hans",
         "hant",
     )
-    res = opencc.OpenCC("s2t").convert(res)
+    res = opencc.OpenCC("s2t").convert(res)  # type: ignore
     assert res == """「我最贊成羅素先生的一句話：『須知參差多態，乃是幸福的本源。』大多數的參差多態都是敏於思索的人創造出來的。」"""
 
     res = punctuation.convert(
@@ -107,7 +114,7 @@ def test_punctuation():
         "hant",
         "hans",
     )
-    res = opencc.OpenCC("t2s").convert(res)
+    res = opencc.OpenCC("t2s").convert(res)  # type: ignore
     assert res == """“我最赞成罗素先生的一句话：‘须知参差多态，乃是幸福的本源。’大多数的参差多态都是敏于思索的人创造出来的。”"""
 
     res = punctuation.convert(
@@ -116,7 +123,7 @@ def test_punctuation():
         "hans",
         "hant",
     )
-    res = opencc.OpenCC("s2t").convert(res)
+    res = opencc.OpenCC("s2t").convert(res)  # type: ignore
     assert res == """「我最贊成羅素先生的一句話：『須知參差多態，乃是幸福的本源。』大多數的參差多態都是敏於思索的人創造出來的。」"""
 
     res = punctuation.convert(
@@ -125,5 +132,5 @@ def test_punctuation():
         "hant",
         "hans",
     )
-    res = opencc.OpenCC("t2s").convert(res)
+    res = opencc.OpenCC("t2s").convert(res)  # type: ignore
     assert res == """『我最赞成罗素先生的一句话：「须知参差多态，乃是幸福的本源。」大多数的参差多态都是敏于思索的人创造出来的。』"""


### PR DESCRIPTION
## Summary
This PR
1. introduces [microsoft/pyright](https://github.com/microsoft/pyright/) for type checking. 
2. Update all possible places to include type hints and fix all type check errors.
3. updates `ci.yaml` to include type checking in CI.

## Why
As a dynamic typing language, Python has been both flexible and troublesome in development due to this feature. `Pyright` is developed by Microsoft and largely used in VS Code's Python hints and language server. By introducing `Pyright` and enforcing type checking, the project can be more sound and less vulnerable to simple type issues.

## Notes
There are quite some `# type: ignore` because `bs4`, `cssutils` and `opencc` are largely lacking type hints themselves. However, still it can help developers feel more confident in refactoring and adding new features with type checking added for all other places.