### PR TITLE
Java狗上来就面向对象了一波

### DIFF
--- a/epubhv/converter.py
+++ b/epubhv/converter.py
@@ -1,0 +1,267 @@
+
+from abc import abstractmethod
+
+import os
+
+from pathlib import Path
+from typing import List, Optional
+import opencc
+
+from bs4 import BeautifulSoup as bs
+from bs4 import NavigableString, PageElement, ResultSet, Tag
+from cssutils import CSSParser
+from cssutils.css import CSSStyleSheet
+
+from epubhv.punctuation import Punctuation
+from epubhv.yomituki import RubySoup, string_containers  # pyright: ignore
+
+WRITING_KEY_LIST: List[str] = [
+    "writing-mode",
+    "-webkit-writing-mode",
+    "-epub-writing-mode",
+]
+V_ITEM_TO_ADD_IN_MANIFEST: str = (
+    '<item id="stylesheet" href="Style/style.css" media-type="text/css" />'
+)
+V_STYLE_LINE: str = (
+    '<link rel="stylesheet" href="../Style/style.css" type="text/css" />'
+)
+V_STYLE_LINE_IN_OPF: str = '<meta content="vertical-rl" name="primary-writing-mode"/>'
+# same as v
+H_STYLE_LINE: str = (
+    '<link rel="stylesheet" href="../Style/style.css" type="text/css" />'
+)
+H_STYLE_LINE_IN_OPF: str = '<meta content="horizontal-lr" name="primary-writing-mode"/>'
+# same as v
+H_ITEM_TO_ADD_IN_MANIFEST: str = (
+    '<item id="stylesheet" href="Style/style.css" media-type="text/css" />'
+)
+
+
+STYLE = {"vertical":{
+    "page-progression-direction": "ltr",
+    "style_line_in_opf":V_STYLE_LINE_IN_OPF,
+    "primary-writing-mode":"vertical-rl",
+    "item_to_add_in_manifest":V_ITEM_TO_ADD_IN_MANIFEST
+},"horizontal":{
+    "page-progression-direction": "rtl",
+    "style_line_in_opf":H_STYLE_LINE_IN_OPF,
+    "primary-writing-mode":"horizontal-lr",
+    "item_to_add_in_manifest":H_ITEM_TO_ADD_IN_MANIFEST
+}}
+class Converter:
+
+    def process_css(self, css_string):
+        return css_string
+
+    def process_content(self, content):
+        return content
+
+    def process_opf(self, soup):
+        return soup
+    
+    def no_css(self, opf_dir):
+        # do nothing
+        pass
+
+    def set_data(self, data):
+        # do nothing
+        pass
+
+class Direction_Converter(Converter):
+    
+    def process_opf(self, soup):
+        spine: Optional[Tag | NavigableString] = soup.find("spine")
+        direction = self.get_direction()
+        progression_direction = STYLE[direction]["page-progression-direction"]
+        assert spine is not None
+        if spine.attrs.get("page-progression-direction", "") != progression_direction:  # type: ignore
+            spine.attrs["page-progression-direction"] = progression_direction  # type: ignore
+        meta_list: ResultSet[Tag] = soup.find_all("meta")
+        for m in meta_list:
+            if m.attrs.get("name", "") == "primary-writing-mode":
+                m.attrs["content"] = STYLE[direction]["primary-writing-mode"]
+        else:
+            meta_list.append(bs(STYLE[direction]["style_line_in_opf"], "xml").contents[0])  # type: ignore
+        if self._need_update_manifest == True:
+            # add css item to manifest items
+            soup.find_all("manifest")[0].append(
+                bs(STYLE[direction]["item_to_add_in_manifest"], "xml").contents[0]
+            )
+        return soup
+    
+    def add_stylesheet_to_html(self, soup: bs, style_line):
+        # Find the head section or create if not present
+        head: Optional[Tag | NavigableString] = soup.find("head")
+        if not head or type(head) is NavigableString:
+            head = soup.new_tag("head")  # type: ignore
+            soup.html.insert(0, head)  # type: ignore
+        # Add the stylesheet line inside the head section
+        head.append(bs(style_line, "html.parser").contents[0])
+
+    @abstractmethod
+    def get_direction(self):
+        pass
+
+
+class To_Vertical_Converter(Direction_Converter):
+    
+    def __init__(self) -> None:
+        super().__init__()
+        self._need_update_manifest = False
+  
+    def process_css(self, css_string):
+        parser: CSSParser = CSSParser()
+        css_sheet: CSSStyleSheet = parser.parseString(css_string)
+        has_html_or_body: bool = False
+        for s in css_sheet.cssRules.rulesOfType(1):  # type: ignore
+            if s.selectorText == "html":  # type: ignore
+                has_html_or_body = True
+                for w in WRITING_KEY_LIST:
+                    if w not in s.style.keys():  # type: ignore
+                        # set it to vertical
+                        s.style[w] = "vertical-rl"  # type: ignore
+        if not has_html_or_body:
+            css_sheet.add(  # type: ignore
+                """
+                html {
+                    -epub-writing-mode: vertical-rl;
+                    writing-mode: vertical-rl;
+                    -webkit-writing-mode: vertical-rl;
+                }
+                """
+            )
+        return css_sheet.cssText.decode('utf-8')
+    
+    def get_direction(self):
+        return "vertical"
+
+    def no_css(self, opf_dir):
+        # if we have no css file in the epub than we create one.
+        style_path: Path = Path(opf_dir) / Path("Style")
+        if not style_path.exists():
+            os.mkdir(style_path)
+        new_css_file: Path = style_path / Path("style.css")
+        with open(new_css_file, "w", encoding="utf-8", errors="ignore") as file:
+            file.write(
+                """
+@charset "utf-8";
+html {
+-epub-writing-mode: vertical-rl;
+writing-mode: vertical-rl;
+-webkit-writing-mode: vertical-rl;
+}
+                    """
+            )
+        self._need_update_manifest = True
+    
+    def process_content(self, content):
+        if self._need_update_manifest == False:
+            return content
+        soup: bs = bs(content, "html.parser")
+        super().add_stylesheet_to_html(self, soup, V_STYLE_LINE)
+        return str(soup)
+
+
+class To_Horizontal_Converter(Converter):
+  
+    def process_css(self, css_string):
+        parser: CSSParser = CSSParser()
+        css_sheet: CSSStyleSheet = parser.parseString(css_string)
+        for s in css_sheet.cssRules.rulesOfType(1):  # type: ignore
+            for k in s.style.keys():  # type: ignore
+                if k in WRITING_KEY_LIST:
+                    del s.style[k]  # type: ignore
+        return css_sheet.cssText.decode('utf-8')
+
+    def get_direction(self):
+        return "horizontal"
+
+    # seems don't need this? 
+    # def process_content(self, content):
+    #     if self._need_update_manifest == False:
+    #         return content
+    #     soup: bs = bs(content, "html.parser")
+    #     super().add_stylesheet_to_html(self, soup, H_STYLE_LINE)
+    #     return str(soup)
+    
+
+class Language_Converter(Converter):
+    
+    def __init__(self):
+        self.convert_punctuation: str = None
+        self.converter = None
+        self.convert_to = None
+        self.method = None
+    
+    def set_data(self, data):
+        if "method" in data:
+            self.method = data["method"]
+        if "convert_punctuation" in data:
+            self.convert_punctuation: str = data["convert_punctuation"]
+        if "convert_to" in data:
+            self.convert_to = data["convert_to"]
+            self.converter = opencc.OpenCC(self.convert_to)
+
+    def process_opf(self, soup):
+        meta_list: ResultSet[Tag] = soup.find_all("meta")
+        writing_mode = None
+        for m in meta_list:
+            if m.attrs.get("name", "") == "primary-writing-mode":
+                writing_mode = m.attrs["content"]
+        if writing_mode == "vertical-rl":
+            self.method = "to_vertical"
+        else:
+            self.method = "to_horizontal"
+  
+    def process_content(self, content):
+        soup: bs = bs(content, "html.parser")
+        html_element: Optional[Tag | NavigableString] = soup.find("html")
+        assert html_element is not None
+        text_elements: ResultSet[PageElement] = html_element.find_all(string=True)  # type: ignore
+
+        element: Tag
+        for element in text_elements:  # type: ignore
+            old_text = element.string
+            if old_text is not None:
+                new_text = self.converter.convert(old_text)  # type: ignore
+                punc = self.convert_punctuation
+                if punc != "none":
+                    if punc == "auto":
+                        if self.convert_to is None:
+                            punc = "s2t" if self.method == "to_vertical" else "t2t"
+                            # default: convert “‘’” to 「『』」 in vertical mode,
+                            # but not to “‘’” in horizontal mode
+                        else:
+                            punc = self.convert_to
+                    source, target = punc.split("2")
+                    punc_converter = Punctuation()
+                    new_text = punc_converter.convert(  # type: ignore
+                        new_text,
+                        horizontal=self.method == "to_horizontal",
+                        source_locale=punc_converter.map_locale(source),  # type: ignore
+                        target_locale=punc_converter.map_locale(target),  # type: ignore
+                    )
+            element.string.replace_with(new_text)  # type: ignore
+            html_element.replace_with(html_element)
+        return str(soup.prettify())
+
+
+class Ruby_Converter(Converter):
+    
+    def __init__(self):
+        self.ruby_language = None
+
+    def process_content(self, content):
+        ruby_soup = bs(
+                    content, "html.parser", string_containers=string_containers
+                )
+        # TODO fix this maybe support unruby
+        r = RubySoup(self.ruby_language, True)
+        r.ruby_soup(ruby_soup.body)
+        return ruby_soup.prettify()
+    
+    def set_data(self, data):
+        print(data)
+        if "ruby_language" in data:
+            self.ruby_language = data["ruby_language"]

--- a/epubhv/epub_processer.py
+++ b/epubhv/epub_processer.py
@@ -1,0 +1,223 @@
+"""
+Follow these steps to change epub books to vertical or horizontal.
+"""
+import logging
+import os
+import shutil
+import zipfile
+from collections import defaultdict, Counter
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import cssutils
+import opencc
+from bs4 import BeautifulSoup as bs, Tag
+
+from langdetect import detect, LangDetectException
+
+cssutils.log.setLevel(logging.CRITICAL)  # type: ignore
+
+def list_all_epub_in_dir(path: Path) -> set[Path]:
+    return set(path.rglob("*.epub"))
+
+
+def make_epub_files_dict(dir_path: Path) -> Dict[str, List[Path]]:
+    files_dict: Dict[str, List[Path]] = defaultdict(list)
+    for root, _, filenames in os.walk(dir_path):
+        for filename in filenames:
+            files_dict[Path(filename).suffix].append(Path(root) / Path(filename))
+    return files_dict
+
+
+def load_opf_meta_data(opf_file: Path) -> bs:
+    with open(opf_file, encoding="utf-8", errors="ignore") as f:
+        content: str = f.read()
+        soup: bs = bs(content, "xml")
+    return soup
+
+
+class Epub_Processer:
+    def __init__(
+        self,
+        file_path: Path,
+        convert_to: Optional[str] = None,
+        convert_punctuation: Optional[str] = "auto",
+        need_ruby: bool = False,
+        need_cantonese: bool = False,
+    ) -> None:
+        # declare instance fields
+        self.epub_file: Path
+        self.has_css_file: bool = False
+        # for language ruby
+        self.need_ruby: bool = need_ruby
+        self.ruby_language = None
+        self.cantonese = need_cantonese
+        self.files_dict: Dict[str, List[Path]] = {}
+        self.content_files_list: List[Path] = []
+        self.book_path: Path
+        self.book_name: str
+        self.opf_file: Path
+        self.converter: Optional[opencc.OpenCC]
+        self.convert_to: Optional[str]
+        self.convert_punctuation: str = "auto"
+
+        # initialize instance fields
+        self.epub_file = file_path
+        if convert_to is not None:
+            self.converter = opencc.OpenCC(convert_to)
+            self.convert_to = convert_to
+        else:
+            self.converter = None
+            self.convert_to = None
+        if convert_punctuation:
+            self.convert_punctuation = convert_punctuation
+
+    def extract_one_epub_to_dir(self) -> None:
+        assert self.epub_file.suffix == ".epub", f"{self.epub_file} Must be epub file"
+        book_name: str = self.epub_file.name.split(".")[0]
+        self.book_name = book_name
+        book_path = Path(".epub_temp_dir") / Path(book_name)
+        Path(".epub_temp_dir").mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(self.epub_file) as f:
+            f.extractall(book_path)
+        self.book_path = book_path
+
+    def make_epub_values(self) -> None:
+        """
+        setups:
+          1. extract the epub files
+          2. make the file dict
+          3. find the key file -> opf file
+          4. find if has css file and make all css files to list
+        """
+        self.extract_one_epub_to_dir()
+        self.files_dict = make_epub_files_dict(self.book_path)
+        self.content_files_list = (
+            self.files_dict.get(".html", [])
+            + self.files_dict.get(".xhtml", [])
+            + self.files_dict.get(".htm", [])
+        )
+        opf_files = self.files_dict.get(".opf", [])
+        assert len(opf_files) == 1, "Epub must have only one opf file"
+        self.opf_file = opf_files[0]
+        self.opf_dir = self.opf_file.parent.absolute()
+
+    def __detect_language(self):
+        c = Counter()
+        for f in self.content_files_list:
+            with open(f, "r", encoding="utf-8", errors="ignore") as f:
+                content: str = f.read()
+            sp: bs = bs(content, "html.parser")
+            if sp.body:
+                body_text: str = sp.body.get_text()
+                try:
+                    language = detect(body_text)
+                    c[language] += 1
+                except LangDetectException:
+                    pass
+        if c:
+            language = c.most_common()[0][0]
+            # WTF sometimes Chinese will detect as ko?
+            # TODO change to a better detect
+            if language in ["ko", "zh-tw"]:
+                self.ruby_language = "cantonese" if self.cantonese else language
+                self.need_ruby = True
+            elif language in ["ja"]:
+                self.ruby_language = "ja"
+                self.need_ruby = True
+            elif language in ["zh", "zh-cn"]:
+                self.ruby_language = "zh"
+                self.need_ruby = True
+
+    def _make_ruby_language(self, soup):
+        if self.need_ruby:
+            # if we need ruby we need to find the ruby language
+            languages = soup.find("dc:language")
+            if languages and 0:
+                language = languages.contents[0]
+                if language in ["ja", "zh", "zh-cn"]:
+                    self.ruby_language = language
+                    self.need_ruby = True
+                else:
+                    print(
+                        f"Ruby feature do not support this language -> {language}, \n for book: {self.book_name} we will ignore it."
+                    )
+                    self.need_ruby = False
+            else:
+                self.__detect_language()
+                if not self.ruby_language:
+                    print(
+                        "There's no language meta data in meta file and can not detect the language, we use Japanese as default. we can not ruby it"
+                    )
+                    self.need_ruby = False
+
+    def process(self, converters:[]):
+        self.make_epub_values()
+        for converter in converters:
+            converter.set_data({
+                "convert_to" : self.convert_to,
+                "convert_punctuation": self.convert_punctuation
+            })
+        with open(self.opf_file, "r", encoding="utf-8", errors="ignore") as opf_file:
+            opf_content: str = opf_file.read()
+            opfSoup: bs = bs(opf_content, "xml")
+            self._make_ruby_language(opfSoup)
+            for converter in converters:
+                converter.set_data({
+                    "ruby_language" : self.ruby_language,
+                })
+            manifest: Tag = opfSoup.find_all("manifest")[0]
+            items = [i for i in manifest.find_all("item")]
+            self.css_files = [
+                self.opf_dir / Path(i.attrs.get("href", ""))
+                for i in items
+                if i.attrs.get("media-type", "") == "text/css"
+            ]
+            
+            self.has_css_file = len(self.css_files) > 0
+            if self.has_css_file:
+                css: Path
+                for css in self.css_files:
+                    with open(css, "r", encoding="utf-8", errors="ignore") as css_file:
+                        css_content: str = css_file.read()
+                        for converter in converters:
+                            css_content = converter.process_css(css_content)
+                    with open(css, "w", encoding="utf-8", errors="ignore") as css_file:
+                        css_file.write(css_content)
+            else:
+                for converter in converters:
+                    converter.no_css(self.opf_dir)
+
+            # css process should before opf process，because update manifest in opf process depends on converter.no_css()
+            for converter in converters:
+                converter.process_opf(opfSoup)
+            
+        with open(self.opf_file, 'w') as opf_file:
+            opf_file.write(str(opfSoup))
+
+        for html_file_path in self.content_files_list:
+            with open(html_file_path, "r", encoding="utf-8", errors="ignore") as content_file:
+                content: str = content_file.read()
+                for converter in converters:
+                    content = converter.process_content(content)
+            with open(html_file_path, "w", encoding="utf-8", errors="ignore") as content_file:
+                content_file.write(content)
+                
+    def pack(self) -> None:
+        dest = "tmp"
+        # lang: str = "original"
+        # if self.convert_to is not None:
+        #     lang = self.convert_to
+        # if self.need_ruby:
+        #     lang = f"{lang}-ruby"
+        # if method == "to_vertical":
+        #     book_name: str = f"{self.book_name}-v-{lang}.epub"
+        # elif method == "to_horizontal":
+        #     book_name: str = f"{self.book_name}-h-{lang}.epub"
+        # else:
+        #     book_name: str = f"{self.book_name}-{lang}.epub"
+        book_name: str = f"{dest}/{self.book_name}_output.epub"
+        shutil.make_archive(base_name=book_name, format="zip", root_dir=self.book_path)
+        os.rename(src=book_name + ".zip", dst=book_name)
+        shutil.rmtree(self.book_path)
+        return book_name

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,75 @@
+
+from pathlib import Path
+from epubhv.epub_processer import Epub_Processer
+from epubhv.converter import Language_Converter, Ruby_Converter, To_Horizontal_Converter, To_Vertical_Converter
+
+def test_to_vertical() -> None:
+    lemo_output = Path("tmp/animal_farm_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/animal_farm.epub"))
+    processer.process([To_Vertical_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    lemo_output.unlink(True)
+
+# test_to_vertical()
+    
+def test_to_horizontal() -> None:
+    lemo_output = Path("tmp/lemo_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/books/lemo.epub"))
+    processer.process([To_Horizontal_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    lemo_output.unlink(True)
+
+# test_to_horizontal()
+
+
+def test_ruby() -> None:
+    lemo_output = Path("tmp/lemo_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/books/lemo.epub"), need_ruby=True)
+    processer.process([Ruby_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    # lemo_output.unlink(True)
+
+# test_ruby()
+    
+
+def test_ruby_to_horizontal() -> None:
+    lemo_output = Path("tmp/lemo_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/books/lemo.epub"), need_ruby=True)
+    processer.process([Ruby_Converter(), To_Horizontal_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    lemo_output.unlink(True)
+
+# test_ruby_to_horizontal()
+
+
+def test_language_converter() -> None:
+    lemo_output = Path("tmp/sanguo_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/sanguo.epub"), "s2t")
+    processer.process([Language_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    lemo_output.unlink(True)
+
+# test_ruby_convert_to()
+
+
+def test_language_ruby_vertical_converter() -> None:
+    lemo_output = Path("tmp/sanguo_output.epub")
+    lemo_output.unlink(True)
+    processer : Epub_Processer = Epub_Processer(Path("tests/test_epub/sanguo.epub"), "s2t", need_ruby=True)
+    # TODO Actually there's problem here, if Direction_Converter comes after Language_Converter, punctuations will be wrong.
+    processer.process([To_Vertical_Converter(), Language_Converter(), Ruby_Converter()])
+    processer.pack()
+    assert lemo_output.exists()
+    lemo_output.unlink(True)
+
+# test_language_ruby_vertical_converter()


### PR DESCRIPTION
refactor: splite converter functions to different classes which can be used alone or combined

除了最后打包输出的文件名嫌麻烦没有按原逻辑处理，其他都跟原逻辑一样。只是把EPUBHV拆分了下（逻辑应该更清晰点）。
和原来相比好处是横竖转换、语言转化、添加ruby三者可以自由组合。